### PR TITLE
Update admin user creation

### DIFF
--- a/Migrations/20250705000000_AddAdminUser.cs
+++ b/Migrations/20250705000000_AddAdminUser.cs
@@ -31,12 +31,14 @@ namespace Stream.Migrations
                 EmailConfirmed = true,
                 SecurityStamp = "00000000-0000-0000-0000-000000000002",
                 ConcurrencyStamp = "00000000-0000-0000-0000-000000000003",
-                PasswordHash = "AQAAAAIAAYagAAAAELiRGCG2l9VmOAXoJ1V8LojRxurx8WcN6iK3PaY5PQExampleHash==",
                 PhoneNumberConfirmed = false,
                 TwoFactorEnabled = false,
                 LockoutEnabled = false,
                 AccessFailedCount = 0
             };
+
+            var hasher = new PasswordHasher<StreamUser>();
+            user.PasswordHash = hasher.HashPassword(user, "Admin123!");
 
             migrationBuilder.InsertData(
                 table: "AspNetUsers",


### PR DESCRIPTION
## Summary
- compute admin password hash at runtime instead of storing a fixed hash

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868e2ee84348328bbe499d5de66b6ce